### PR TITLE
Update imports, .travis.yml, and copyright headers for new repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: go
 go:
-  - 1.5.3
+  - 1.8.5
+  - 1.9.2
 branches:
   only:
     - master
+install: go get -t ./...
 script: go test -v ./... -check.vv
 sudo: false

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Godspeed
-[![TravisCI Build Status](https://img.shields.io/travis/PagerDuty/godspeed/master.svg?style=flat)](https://travis-ci.org/PagerDuty/godspeed)
-[![GoDoc](https://img.shields.io/badge/godspeed-GoDoc-blue.svg?style=flat)](https://godoc.org/github.com/PagerDuty/godspeed)
-[![License](https://img.shields.io/badge/License-BSD_3--Clause-brightgreen.svg?style=flat)](https://github.com/PagerDuty/godspeed/blob/master/LICENSE)
+[![TravisCI Build Status](https://img.shields.io/travis/theckman/godspeed/master.svg?style=flat)](https://travis-ci.org/theckman/godspeed)
+[![GoDoc](https://img.shields.io/badge/godspeed-GoDoc-blue.svg?style=flat)](https://godoc.org/github.com/theckman/godspeed)
+[![License](https://img.shields.io/badge/License-BSD_3--Clause-brightgreen.svg?style=flat)](https://github.com/theckman/godspeed/blob/master/LICENSE)
 
 Godspeed is a statsd client for the Datadog extension of statsd (DogStatsD).
 The name `godspeed` is a bit of a rhyming slang twist on DogStatsD. It's also a
 poke at the fact that the statsd protocol's transport mechanism is UDP...
 
-Check out [GoDoc](https://godoc.org/github.com/PagerDuty/godspeed) for the docs
+Check out [GoDoc](https://godoc.org/github.com/theckman/godspeed) for the docs
 as well as some examples.
 
 DogStatsD is a copyright of `Datadog <info@datadoghq.com>`.
@@ -18,12 +18,12 @@ the full contents of the license.
 
 ## Installation
 ```
-go get -u github.com/PagerDuty/godspeed
+go get -u github.com/theckman/godspeed
 ```
 
 ## Usage
 For more details either look at the `_example_test.go` files directly or view
-the examples on [GoDoc](https://godoc.org/github.com/PagerDuty/godspeed#pkg-examples).
+the examples on [GoDoc](https://godoc.org/github.com/theckman/godspeed#pkg-examples).
 
 ### Emitting a gauge
 ```Go

--- a/async_example_test.go
+++ b/async_example_test.go
@@ -1,10 +1,12 @@
-// Copyright 2014-2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2014-2015 PagerDuty, Inc.
+// Copyright 2018 Tim Heckman
+// All rights reserved.
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
 package godspeed_test
 
-import "github.com/PagerDuty/godspeed"
+import "github.com/theckman/godspeed"
 
 func ExampleNewAsync() {
 	a, err := godspeed.NewAsync(godspeed.DefaultHost, godspeed.DefaultPort, false)

--- a/async_test.go
+++ b/async_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2014-2015 PagerDuty, Inc.
+// Copyright 2018 Tim Heckman
+// All rights reserved.
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
@@ -9,8 +11,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/PagerDuty/godspeed"
-	"github.com/PagerDuty/godspeed/gspdtest"
+	"github.com/theckman/godspeed"
+	"github.com/theckman/godspeed/gspdtest"
 
 	// this is *C comes from
 	. "gopkg.in/check.v1"

--- a/events_example_test.go
+++ b/events_example_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2014-2015 PagerDuty, Inc.
+// Copyright 2018 Tim Heckman
+// All rights reserved.
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
@@ -7,7 +9,7 @@ package godspeed_test
 import (
 	"fmt"
 
-	"github.com/PagerDuty/godspeed"
+	"github.com/theckman/godspeed"
 )
 
 func ExampleGodspeed_Event() {

--- a/example_test.go
+++ b/example_test.go
@@ -1,10 +1,12 @@
-// Copyright 2014-2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2014-2015 PagerDuty, Inc.
+// Copyright 2018 Tim Heckman
+// All rights reserved.
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
 package godspeed_test
 
-import "github.com/PagerDuty/godspeed"
+import "github.com/theckman/godspeed"
 
 func Example() {
 	// this uses the default host and port (127.0.0.1:8125)

--- a/godspeed_example_test.go
+++ b/godspeed_example_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2014-2015 PagerDuty, Inc.
+// Copyright 2018 Tim Heckman
+// All rights reserved.
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
@@ -7,7 +9,7 @@ package godspeed_test
 import (
 	"fmt"
 
-	"github.com/PagerDuty/godspeed"
+	"github.com/theckman/godspeed"
 )
 
 func ExampleNew() {

--- a/godspeed_test.go
+++ b/godspeed_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2014-2015 PagerDuty, Inc.
+// Copyright 2018 Tim Heckman
+// All rights reserved.
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
@@ -9,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/PagerDuty/godspeed"
-	"github.com/PagerDuty/godspeed/gspdtest"
+	"github.com/theckman/godspeed"
+	"github.com/theckman/godspeed/gspdtest"
 
 	// this is *C comes from
 	. "gopkg.in/check.v1"

--- a/service_checks_example_test.go
+++ b/service_checks_example_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2014-2015 PagerDuty, Inc.
+// Copyright 2018 Tim Heckman
+// All rights reserved.
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
@@ -8,7 +10,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/PagerDuty/godspeed"
+	"github.com/theckman/godspeed"
 )
 
 func ExampleGodspeed_ServiceCheck() {

--- a/service_checks_test.go
+++ b/service_checks_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2014-2015 PagerDuty, Inc.
+// Copyright 2018 Tim Heckman
+// All rights reserved.
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
@@ -7,7 +9,7 @@ package godspeed_test
 import (
 	"fmt"
 
-	"github.com/PagerDuty/godspeed"
+	"github.com/theckman/godspeed"
 	. "gopkg.in/check.v1"
 )
 

--- a/stats_example_test.go
+++ b/stats_example_test.go
@@ -1,10 +1,12 @@
-// Copyright 2014-2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2014-2015 PagerDuty, Inc.
+// Copyright 2018 Tim Heckman
+// All rights reserved.
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
 package godspeed_test
 
-import "github.com/PagerDuty/godspeed"
+import "github.com/theckman/godspeed"
 
 func ExampleGodspeed_Send() {
 	g, err := godspeed.NewDefault()

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2014-2015 PagerDuty, Inc.
+// Copyright 2018 Tim Heckman
+// All rights reserved.
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
@@ -7,7 +9,7 @@ package godspeed_test
 import (
 	"math/rand"
 
-	"github.com/PagerDuty/godspeed"
+	"github.com/theckman/godspeed"
 
 	// this is *C comes from
 	. "gopkg.in/check.v1"


### PR DESCRIPTION
This change updates the repository to ensure that all of the import paths point
to the new repository. This is needed as we fork `PagerDuty/godspeed` and look
to become the canonical repository.

In addition to changing the import paths, this also includes a copyright for Tim
Heckman on files I've modified as part of this changes.

Finally, this updates the `.travis.yml` file to test against modern versions of
the Go runtime.

Signed-off-by: Tim Heckman <t@heckman.io>