### PR TITLE
Fix incorrect import added in a79d8195

### DIFF
--- a/events_test.go
+++ b/events_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/PagerDuty/godspeed"
+	"github.com/theckman/godspeed"
 	// this is where *C comes from
 	. "gopkg.in/check.v1"
 )


### PR DESCRIPTION
An incorrect import was added in a79d8195bf0e74dca99764fdbe162d2e73269a63. This
change updates the import to point to the correct repository instead.

Signed-off-by: Tim Heckman <t@heckman.io>