### PR TITLE
Optimize the uniqueTags function to be faster with less allocs

### DIFF
--- a/shared.go
+++ b/shared.go
@@ -21,36 +21,38 @@ func removePipes(s string) string {
 
 // function to make sure tags are unique
 func uniqueTags(gt, t []string) []string {
-	allTags := make([]string, 0, len(gt)+len(t))
-	allTags = append(allTags, gt...)
-	allTags = append(allTags, t...)
-	t = allTags
+	tags := make([]string, len(gt)+len(t))
+
+	copy(tags, gt)
+	copy(tags[len(gt):], t)
 
 	// if the tag slice is empty avoid allocation
-	if len(t) < 1 {
+	if len(tags) == 0 {
 		return nil
 	}
 
 	// build a map to track which values we've seen
-	s := make(map[string]bool)
+	// make sure the map is big enough to store all tags
+	// to avoid further allocations as we add more items
+	s := make(map[string]struct{}, len(tags))
 
 	// loop over each string provided
 	// if the value is not in the map then replace
 	// the value at t[len(s)] so that we always have
 	// only unique tags at the beginning of the slice
-	for i, v := range t {
+	for i, v := range tags {
 		if _, x := s[v]; !x {
 			// only change the value if needed
-			if i != len(s) {
-				t[len(s)] = v
+			if sz := len(s); sz != i {
+				tags[sz] = v
 			}
 
-			s[v] = true
+			s[v] = struct{}{}
 		}
 	}
 
 	// based on the size of the map we know
 	// how many unique tags there were
 	// so return that slice
-	return []string(t[:len(s)])
+	return tags[:len(s)]
 }

--- a/shared_test.go
+++ b/shared_test.go
@@ -1,0 +1,54 @@
+package godspeed
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_uniqueTags(t *testing.T) {
+	tests := []struct {
+		i1, i2 []string
+		o      []string
+	}{
+		{
+			i1: []string{"these", "are", "some", "example", "some", "tags", "are"},
+			o:  []string{"these", "are", "some", "example", "tags"},
+		},
+		{
+			i1: []string{"a", "b", "c"},
+			i2: []string{"d", "e", "a"},
+			o:  []string{"a", "b", "c", "d", "e"},
+		},
+	}
+
+	for _, tt := range tests {
+		out := uniqueTags(tt.i1, tt.i2)
+		if !reflect.DeepEqual(tt.o, out) {
+			t.Errorf("uniqueTag(%#v, %#v) = %#v; want %#v", tt.i1, tt.i2, out, tt.o)
+		}
+	}
+}
+
+func BenchmarkUniqueTags(b *testing.B) {
+	res := make([][]string, b.N)
+
+	tags1 := []string{
+		"this", "is", "some:tag", "with", "a", "value", "and",
+		"I am", "just going to", "keep", "m", "a", "k", "i", "n", "g", " ",
+		"tags so", "we", "have", "a", "decent", "number", "of", "tags", "to",
+		"benchmark", ".", "I was", "hoping", "to be", "able", "to use", "more",
+		"tags.", "Also,", "did I", "invent", "my", "own", "lorem",
+		"i", "p", "s", "u", "m", "?",
+	}
+
+	tags2 := []string{
+		"back", "again", "with", "some", "nonsense", "tags", "to", "pad", "how",
+		"much data", "we", "are", "using", "to", "test", ".", "I", "have", "become",
+		"much", "lazier", "since", "tags1", "so", "we", "will", "have", "a", "few",
+		"l", "e", "s", "s", " ", "t", "a", "g", "s",
+	}
+
+	for i := 0; i < b.N; i++ {
+		res[i] = uniqueTags(tags1, tags2)
+	}
+}


### PR DESCRIPTION
This change optimizes the internal `uniqeTags()` function to be more efficient.
This was done with three modifications being made:

* use `copy()` instead of `append()`
* when allocating the map, ensure it's large enough to avoid further allocations
* for the map, use values with type `struct{}` instead of `bool`

The changes above resulted in the following improvements:

```
benchmark                 old ns/op     new ns/op     delta
BenchmarkUniqueTags-8     12692         6619          -47.85%

benchmark                 old allocs     new allocs     delta
BenchmarkUniqueTags-8     8              3              -62.50%

benchmark                 old bytes     new bytes     delta
BenchmarkUniqueTags-8     6805          4152          -38.99%
```

Signed-off-by: Tim Heckman <t@heckman.io>

/cc @akrylysov @deepakprabhakara