### PR TITLE
Use WriteRune(x) instead of WriteString(string(x))

### DIFF
--- a/events.go
+++ b/events.go
@@ -53,7 +53,7 @@ func (g *Godspeed) Event(title, text string, fields map[string]string, tags []st
 		for i, v := range eventKeys {
 			if mv, ok := fields[v]; ok {
 				buf.WriteString("|")
-				buf.WriteString(string(eventMarkers[i]))
+				buf.WriteRune(eventMarkers[i])
 				buf.WriteString(":")
 				pipesReplacer.WriteString(&buf, mv)
 			}


### PR DESCRIPTION
This simplifies the code to write the rune directly of doing a string conversion
first.

Signed-off-by: Tim Heckman <t@heckman.io>

/cc @akrylysov @deepakprabhakara