### PR TITLE
Remove dead test code discovered by the megacheck

### DIFF
--- a/godspeed_test.go
+++ b/godspeed_test.go
@@ -18,8 +18,6 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-const closedChan = "return channel (out) closed prematurely"
-
 func Test(t *testing.T) { TestingT(t) }
 
 type TestSuite struct {
@@ -111,7 +109,6 @@ func (t *TestSuite) TestAddTags(c *C) {
 	}
 
 	tags2 := []string{"test3", "test4", "test5", "test4"}
-	tags = append(tags, tags2...)
 
 	t.g.AddTags(tags2)
 	c.Assert(len(t.g.Tags), Equals, 5)


### PR DESCRIPTION
This removes two lines of code from the `godpeed_test.go` file that was
basically unused. This should have no impact on any consumers of the package.

Signed-off-by: Tim Heckman <t@heckman.io>